### PR TITLE
feat: support npu legacy checkpoint in megatron-refactor

### DIFF
--- a/scripts/train/megatron/convert/qwen2_5/convert_hf_to_mcore.sh
+++ b/scripts/train/megatron/convert/qwen2_5/convert_hf_to_mcore.sh
@@ -13,10 +13,10 @@ MASTER_PORT=$(shuf -n 1 -i 10000-65535)
 TP=${TP:-"2"}
 PP=${PP:-"2"}
 PRECISION=${PRECISION:-"bf16"}
-USE_TE=${USE_TE:-"true"}
+USE_TE=${USE_TE:-"false"}
 MG2HF=${MG2HF:-"false"}
 HF_CKPT_PATH=${HF_CKPT_PATH:-"Qwen/Qwen2.5-3B-Instruct"}
-TARGET_CKPT_PATH=${TARGET_CKPT_PATH:-"./mg_models/Qwen2.5-hf-to-mcore-te-tp${TP}-pp${PP}"}
+TARGET_CKPT_PATH=${TARGET_CKPT_PATH:-"./mg_models/Qwen2.5-hf-to-mcore-local-tp${TP}-pp${PP}"}
 
 # Model architecture args are auto-derived from --model-path (HF config.json).
 # No need for MODEL_SIZE-based hardcoding.

--- a/scripts/train/megatron/convert/qwen2_5/convert_mcore_to_hf.sh
+++ b/scripts/train/megatron/convert/qwen2_5/convert_mcore_to_hf.sh
@@ -12,9 +12,9 @@ PP=${PP:-"2"}
 MG_MODEL_PATH=${MG_MODEL_PATH:-"./checkpoints/sft/checkpoint/sft-mcore-qwen2_5-3B-lr-5e-6-minlr-0.0-bs-4-gbs-16-seqlen-4096-pr-bf16-tp-2-pp-2-cp-1-ac-none-do-true-sp-false-ti-10000-wf-.00016"}
 HF_CKPT_PATH=${HF_CKPT_PATH:-"Qwen/Qwen2.5-3B-Instruct"}
 PRECISION=${PRECISION:-"fp32"}
-USE_TE=${USE_TE:-"true"}
+USE_TE=${USE_TE:-"false"}
 MG2HF=${MG2HF:-"true"}
-TARGET_CKPT_PATH=${TARGET_CKPT_PATH:-"./hf_models_from_mg/Qwen2.5-hf-to-mcore-te-tp${TP}-pp${PP}"}
+TARGET_CKPT_PATH=${TARGET_CKPT_PATH:-"./hf_models_from_mg/Qwen2.5-hf-to-mcore-local-tp${TP}-pp${PP}"}
 
 # Model architecture args are auto-derived from --model-path (HF config.json).
 

--- a/scripts/train/megatron/convert/qwen2_5/convert_mcore_to_hf_dpo.sh
+++ b/scripts/train/megatron/convert/qwen2_5/convert_mcore_to_hf_dpo.sh
@@ -12,9 +12,9 @@ PP=${PP:-"2"}
 MG_MODEL_PATH=${MG_MODEL_PATH:-"./checkpoints/dpo/checkpoint/dpo-mcore-qwen2_5-3B-lr-5e-6-minlr-0.0-bs-4-gbs-16-seqlen-4096-pr-bf16-tp-2-pp-2-cp-1-ac-none-do-true-sp-false-ti-10000-wf-.00016"}
 HF_CKPT_PATH=${HF_CKPT_PATH:-"Qwen/Qwen2.5-3B-Instruct"}
 PRECISION=${PRECISION:-"fp32"}
-USE_TE=${USE_TE:-"true"}
+USE_TE=${USE_TE:-"false"}
 MG2HF=${MG2HF:-"true"}
-TARGET_CKPT_PATH=${TARGET_CKPT_PATH:-"./hf_models_from_mg/Qwen2.5-hf-to-mcore-te-tp${TP}-pp${PP}"}
+TARGET_CKPT_PATH=${TARGET_CKPT_PATH:-"./hf_models_from_mg/Qwen2.5-hf-to-mcore-local-tp${TP}-pp${PP}"}
 
 # Model architecture args are auto-derived from --model-path (HF config.json).
 

--- a/scripts/train/megatron/train/npu/sft_conv.sh
+++ b/scripts/train/megatron/train/npu/sft_conv.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Activate conda environment (required for torch-npu)
-source /home/ma-user/miniconda3/bin/activate
+# conda already activated by wrapper
 
 export CUDA_DEVICE_MAX_CONNECTIONS=1
 export OMP_NUM_THREADS=1
@@ -172,6 +172,14 @@ find ${PRETRAIN_CHECKPOINT_PATH} -maxdepth 1 -type f -name "*.json" -print0 | xa
 find ${PRETRAIN_CHECKPOINT_PATH} -maxdepth 1 -type f -name "merge*" -print0 | xargs -0 cp -t ${SAVED_PRETRAIN_CHECKPOINT_PATH} 2>/dev/null || true
 
 # ==============================
+# Checkpoint format (Megatron-Core / MindSpeed)
+# 默认镜像里多为 ckpt_format=torch_dist → 保存 *.distcp，AutoAlign mcore→HF（bridge + qwen.common）只认 legacy .pt。
+# 显式 --ckpt-format torch → mp_rank_XX/model_optim_rng.pt，可与 5_convert_to_hf.sh / mcore_to_hf 脚本衔接。
+# 若需改回分布式检查点：export CKPT_FORMAT=torch_dist（或从 megatron_options 中去掉本段）。
+# ==============================
+CKPT_FORMAT=${CKPT_FORMAT:-torch}
+
+# ==============================
 # Full Configuration
 # ==============================
 load_options=" \
@@ -204,6 +212,7 @@ megatron_options="  \
     --tensor-model-parallel-size ${TP} \
     --pipeline-model-parallel-size ${PP} \
     --context-parallel-size ${CP} \
+    --ckpt-format ${CKPT_FORMAT} \
     --num-workers 8 \
     --rotary-seq-len-interpolation-factor 1 \
     ${REPORT_TO:+--report-to $REPORT_TO} \

--- a/src/autoalign/megatron/bridge.py
+++ b/src/autoalign/megatron/bridge.py
@@ -18,7 +18,7 @@ Usage::
 import os
 import re
 from collections import defaultdict
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import torch
@@ -269,6 +269,53 @@ class GPTBridge:
     #  Megatron Checkpoint Save / Load (TP + PP + EP)
     # ================================================================== #
 
+    @staticmethod
+    def _resolve_megatron_legacy_shard_path(checkpoint_name: str) -> str:
+        """Map get_checkpoint_name() output to an on-disk shard file.
+
+        MindSpeed / some Megatron builds save under ``mp_rank_XX_YYY/`` (PP/DP suffix) while
+        ``get_checkpoint_name`` may only return ``mp_rank_XX/model_optim_rng.pt``.  If the
+        canonical path is missing, glob under the same ``iter_*`` directory.
+        """
+        if os.path.isfile(checkpoint_name):
+            return checkpoint_name
+        fname = os.path.basename(checkpoint_name)
+        shard_dir = os.path.dirname(checkpoint_name)
+        iter_dir = os.path.dirname(shard_dir)
+        prefix = os.path.basename(shard_dir)
+        if not os.path.isdir(iter_dir):
+            return checkpoint_name
+        m = re.match(r"mp_rank_(\d+)", prefix)
+        if not m:
+            return checkpoint_name
+        tp_id = int(m.group(1))
+        rank_dir_re = re.compile(rf"^mp_rank_{tp_id:02d}($|_)")
+
+        def _first_existing(names: Tuple[str, ...]) -> Optional[str]:
+            candidates: List[Tuple[int, str]] = []
+            for entry in sorted(os.listdir(iter_dir)):
+                if not rank_dir_re.match(entry):
+                    continue
+                ed = os.path.join(iter_dir, entry)
+                if not os.path.isdir(ed):
+                    continue
+                for n in names:
+                    fpath = os.path.join(ed, n)
+                    if os.path.isfile(fpath):
+                        candidates.append((len(entry), fpath))
+                        break
+            if not candidates:
+                return None
+            candidates.sort(key=lambda x: x[0])
+            chosen = candidates[0][1]
+            print(f"[bridge] resolved missing {checkpoint_name} -> {chosen}")
+            return chosen
+
+        resolved = _first_existing((fname, "model_rng.pt", "model.pt"))
+        if resolved:
+            return resolved
+        return checkpoint_name
+
     def load_mg_state_dict(self, args) -> Dict[str, torch.Tensor]:
         """Load Megatron checkpoint shards and gather into a full state dict.
 
@@ -291,6 +338,26 @@ class GPTBridge:
 
         mid_state = defaultdict(list)
 
+        # torch>=2.4 + torch_npu: Megatron legacy .pt shards pickle non-tensor globals
+        # (e.g. megatron.core.enums.ModelType). Allowlist + weights_only=False for local ckpts.
+        if hasattr(torch.serialization, "add_safe_globals"):
+            import argparse
+            from megatron.core.transformer.enums import AttnBackend
+
+            _safe = [argparse.Namespace, AttnBackend]
+            try:
+                from megatron.core.enums import ModelType
+                _safe.append(ModelType)
+            except ImportError:
+                pass
+            torch.serialization.add_safe_globals(_safe)
+
+        def _load_megatron_shard(path: str):
+            try:
+                return torch.load(path, map_location="cpu", weights_only=False)
+            except TypeError:
+                return torch.load(path, map_location="cpu")
+
         for tp_rank in range(tp_size):
             for ep_rank in range(ep_size if has_experts else 1):
                 for pp_rank in range(pp_size):
@@ -299,16 +366,9 @@ class GPTBridge:
                         tp_rank, tp_size, pp_rank, pp_size,
                         ep_rank, ep_size, has_experts,
                     )
+                    checkpoint_name = self._resolve_megatron_legacy_shard_path(checkpoint_name)
                     print(f'load {checkpoint_name}')
-                    # torch_npu replaces torch.load with restricted unpickler
-                    # that requires explicit allowlist for non-tensor types
-                    if hasattr(torch.serialization, 'add_safe_globals'):
-                        import argparse
-                        from megatron.core.transformer.enums import AttnBackend
-                        torch.serialization.add_safe_globals([argparse.Namespace, AttnBackend])
-                    split_state = torch.load(
-                        checkpoint_name, map_location="cpu",
-                    )['model']
+                    split_state = _load_megatron_shard(checkpoint_name)["model"]
 
                     for k, v in split_state.items():
                         # PP: remap local layer index -> global


### PR DESCRIPTION
Improves Ascend NPU / MindSpeed workflows when using legacy Megatron checkpoints (model_optim_rng.pt under mp_rank_* shards): safer torch.load under recent PyTorch + torch_npu, resilient shard path resolution when on-disk layout differs from get_checkpoint_name(), and explicit -**-ckpt-format torch** in the NPU SFT launcher. Qwen2.5 HF↔mcore helper scripts default to USE_TE=false and local output directory naming for consistency with **--transformer-impl local training.**