### PR TITLE
  feat(megatron): support Qwen3 / Qwen3-MoE

### DIFF
--- a/src/autoalign/megatron/bridge.py
+++ b/src/autoalign/megatron/bridge.py
@@ -25,7 +25,7 @@ import torch
 
 from collections.abc import Mapping, Sequence
 
-__all__ = ["GPTBridge", "Qwen2Bridge", "get_bridge"]
+__all__ = ["GPTBridge", "Qwen2Bridge", "Qwen3Bridge", "get_bridge"]
 
 
 # ---------------------------------------------------------------------------
@@ -98,10 +98,12 @@ class GPTBridge:
             hf_model = hf_model.bfloat16()
 
         with torch.no_grad():
-            # Embedding
-            mg_model.embedding.word_embeddings.weight.copy_(
-                _deep_getattr(hf_model, self.hf_embed_key)
-            )
+            # Embedding — MG may be padded to a multiple of (vocab_divisor *
+            # tp_size) so we copy into the first hf_vocab rows and leave any
+            # padding rows at their initialized (zero) values.
+            hf_embed = _deep_getattr(hf_model, self.hf_embed_key)
+            mg_embed = mg_model.embedding.word_embeddings.weight
+            mg_embed[:hf_embed.shape[0]].copy_(hf_embed)
             # Transformer layers
             hf_layers = _deep_getattr(hf_model, self.hf_layers_prefix)
             for mglayer, hflayer in zip(mg_model.decoder.layers, hf_layers):
@@ -110,11 +112,11 @@ class GPTBridge:
             mg_model.decoder.final_layernorm.weight.copy_(
                 _deep_getattr(hf_model, self.hf_final_norm_key)
             )
-            # LM head (only when untied)
+            # LM head (only when untied) — same vocab-padding consideration
             if args.untie_embeddings_and_output_weights:
-                mg_model.output_layer.weight.copy_(
-                    _deep_getattr(hf_model, self.hf_lm_head_key)
-                )
+                hf_head = _deep_getattr(hf_model, self.hf_lm_head_key)
+                mg_head = mg_model.output_layer.weight
+                mg_head[:hf_head.shape[0]].copy_(hf_head)
 
     def mg_to_hf(self, mg_model, hf_model, args):
         """Copy weights from a Megatron model into an HF model (in-place)."""
@@ -126,10 +128,11 @@ class GPTBridge:
             hf_model = hf_model.bfloat16()
 
         with torch.no_grad():
-            # Embedding
-            _deep_getattr(hf_model, self.hf_embed_key).copy_(
-                mg_model.embedding.word_embeddings.weight
-            )
+            # Embedding — MG may be vocab-padded; only copy back the first
+            # hf_vocab rows.
+            hf_embed = _deep_getattr(hf_model, self.hf_embed_key)
+            mg_embed = mg_model.embedding.word_embeddings.weight
+            hf_embed.copy_(mg_embed[:hf_embed.shape[0]])
             # Transformer layers
             hf_layers = _deep_getattr(hf_model, self.hf_layers_prefix)
             for mglayer, hflayer in zip(mg_model.decoder.layers, hf_layers):
@@ -138,11 +141,11 @@ class GPTBridge:
             _deep_getattr(hf_model, self.hf_final_norm_key).copy_(
                 mg_model.decoder.final_layernorm.weight
             )
-            # LM head
+            # LM head — same vocab-padding consideration
             if args.untie_embeddings_and_output_weights:
-                _deep_getattr(hf_model, self.hf_lm_head_key).copy_(
-                    mg_model.output_layer.weight
-                )
+                hf_head = _deep_getattr(hf_model, self.hf_lm_head_key)
+                mg_head = mg_model.output_layer.weight
+                hf_head.copy_(mg_head[:hf_head.shape[0]])
 
     def _convert_layer_hf_to_mg(self, hflayer, mglayer, args):
         """Convert a single transformer layer HF -> Megatron.
@@ -174,7 +177,9 @@ class GPTBridge:
         if '_extra_state' in key:
             return tensor
 
-        head_dim = args.hidden_size // args.num_attention_heads
+        head_dim = getattr(args, "kv_channels", None) or (
+            args.hidden_size // args.num_attention_heads
+        )
         group_per_split = args.num_query_groups // tp_size
 
         # --- QKV ---
@@ -241,7 +246,9 @@ class GPTBridge:
         if 'norm' in key or 'router' in key or ('gate' in key and 'linear' not in key):
             return shards[0]
 
-        head_dim = args.hidden_size // args.num_attention_heads
+        head_dim = getattr(args, "kv_channels", None) or (
+            args.hidden_size // args.num_attention_heads
+        )
         tp_size = len(shards)
         group_per_split = args.num_query_groups // tp_size
 
@@ -500,6 +507,23 @@ class GPTBridge:
 
                         model_split[new_k] = target_v
 
+                    # Weight-tying + PP: state_dict_for_save_checkpoint() omits
+                    # output_layer.weight when it is tied to embedding, but with
+                    # PP>1 the last PP rank needs it because each rank loads its
+                    # own shard independently.
+                    if (pp_size > 1
+                            and pp_rank == pp_size - 1
+                            and not args.untie_embeddings_and_output_weights
+                            and 'output_layer.weight' not in model_split):
+                        embed_key = 'embedding.word_embeddings.weight'
+                        if embed_key in full_model:
+                            embed_w = full_model[embed_key]
+                            if tp_size > 1:
+                                embed_w = self.split_tensor_for_tp(
+                                    'output_layer.weight', embed_w,
+                                    tp_rank, tp_size, args)
+                            model_split['output_layer.weight'] = embed_w
+
                     checkpoint_name = self._checkpoint_name(
                         get_checkpoint_name, args.save, 0, True,
                         tp_rank, tp_size, pp_rank, pp_size,
@@ -549,7 +573,9 @@ class Qwen2Bridge(GPTBridge):
         use_te = args.transformer_impl == "transformer_engine"
         num_query_groups = args.num_query_groups
         hidden_size = args.hidden_size
-        head_dim = hidden_size // args.num_attention_heads
+        head_dim = getattr(args, "kv_channels", None) or (
+            hidden_size // args.num_attention_heads
+        )
 
         # --- Input LayerNorm ---
         if use_te:
@@ -621,9 +647,11 @@ class Qwen2Bridge(GPTBridge):
         use_te = args.transformer_impl == "transformer_engine"
         num_query_groups = args.num_query_groups
         hidden_size = args.hidden_size
-        head_dim = hidden_size // args.num_attention_heads
+        head_dim = getattr(args, "kv_channels", None) or (
+            hidden_size // args.num_attention_heads
+        )
         value_num_per_group = args.num_attention_heads // num_query_groups
-        q_dim_per_group = hidden_size // num_query_groups
+        q_dim_per_group = value_num_per_group * head_dim
         kv_dim_per_group = head_dim
 
         # --- Input LayerNorm ---
@@ -705,12 +733,204 @@ class Qwen2Bridge(GPTBridge):
 
 
 # ---------------------------------------------------------------------------
+# Qwen3 / Qwen3-MoE Bridge
+# ---------------------------------------------------------------------------
+
+class Qwen3Bridge(Qwen2Bridge):
+    """Bridge for the Qwen3 / Qwen3-MoE model family.
+
+    Differences from Qwen2:
+    - No QKV bias.
+    - Q/K norm on Q and K projections before attention. HF Qwen3 uses
+      RMSNorm here (``self_attn.q_norm`` / ``k_norm``); mcore exposes this
+      via the ``qk_layernorm=True`` flag and the submodules are named
+      ``self_attention.q_layernorm`` / ``k_layernorm`` for historical
+      reasons, but they are instantiated as RMSNorm when
+      ``config.normalization == "RMSNorm"``. Weight copy is shape-identical
+      either way. Verified on NPU + MindSpeed + mcore core_v0.12.1: both
+      TE and local layer specs route through ``mindspeed...PTNorm``, which
+      dispatches to RMSNorm when ``config.normalization == "RMSNorm"``.
+    - Qwen3-MoE has no shared-expert gate (Qwen2.5-MoE had one).
+    """
+
+    def _convert_layer_hf_to_mg(self, hflayer, mglayer, args):
+        use_te = args.transformer_impl == "transformer_engine"
+        num_query_groups = args.num_query_groups
+        hidden_size = args.hidden_size
+        head_dim = getattr(args, "kv_channels", None) or (
+            hidden_size // args.num_attention_heads
+        )
+
+        # --- Input LayerNorm ---
+        if use_te:
+            mglayer.self_attention.linear_qkv.layer_norm_weight.copy_(
+                hflayer.input_layernorm.weight
+            )
+        else:
+            mglayer.input_layernorm.weight.copy_(hflayer.input_layernorm.weight)
+
+        # --- QKV merge (interleaved by query groups) ---
+        q_w = hflayer.self_attn.q_proj.weight.view(num_query_groups, -1, head_dim, hidden_size)
+        k_w = hflayer.self_attn.k_proj.weight.view(num_query_groups, -1, head_dim, hidden_size)
+        v_w = hflayer.self_attn.v_proj.weight.view(num_query_groups, -1, head_dim, hidden_size)
+        qkv_w = torch.cat([q_w, k_w, v_w], dim=1).view(-1, hidden_size).contiguous()
+        mglayer.self_attention.linear_qkv.weight.copy_(qkv_w)
+        # Qwen3 has no QKV bias — skip.
+
+        # --- Q/K LayerNorm (Qwen3-specific) ---
+        if getattr(args, "qk_layernorm", False):
+            mglayer.self_attention.q_layernorm.weight.copy_(
+                hflayer.self_attn.q_norm.weight
+            )
+            mglayer.self_attention.k_layernorm.weight.copy_(
+                hflayer.self_attn.k_norm.weight
+            )
+
+        # --- O projection ---
+        mglayer.self_attention.linear_proj.weight.copy_(
+            hflayer.self_attn.o_proj.weight
+        )
+
+        # --- MLP / MoE ---
+        if args.num_experts is None:
+            fc1 = torch.cat([hflayer.mlp.gate_proj.weight,
+                             hflayer.mlp.up_proj.weight])
+            mglayer.mlp.linear_fc1.weight.copy_(fc1)
+            mglayer.mlp.linear_fc2.weight.copy_(hflayer.mlp.down_proj.weight)
+        else:
+            mglayer.mlp.router.weight.copy_(hflayer.mlp.gate.weight)
+            for hf_expert, mg_expert in zip(
+                hflayer.mlp.experts, mglayer.mlp.experts.local_experts
+            ):
+                fc1 = torch.cat([hf_expert.gate_proj.weight,
+                                 hf_expert.up_proj.weight])
+                mg_expert.linear_fc1.weight.copy_(fc1)
+                mg_expert.linear_fc2.weight.copy_(hf_expert.down_proj.weight)
+            # Qwen3-MoE removed the shared-expert gate. Guard for forward
+            # compatibility: only run if BOTH HF and mcore sides have it.
+            if hasattr(hflayer.mlp, "shared_expert_gate") and hasattr(
+                mglayer.mlp, "shared_expert_gate"
+            ):
+                mglayer.mlp.shared_expert_gate.weight.copy_(
+                    hflayer.mlp.shared_expert_gate.weight
+                )
+                shared_fc1 = torch.cat([
+                    hflayer.mlp.shared_expert.gate_proj.weight,
+                    hflayer.mlp.shared_expert.up_proj.weight,
+                ])
+                mglayer.mlp.shared_expert.linear_fc1.weight.copy_(shared_fc1)
+                mglayer.mlp.shared_expert.linear_fc2.weight.copy_(
+                    hflayer.mlp.shared_expert.down_proj.weight
+                )
+
+        # --- Post-attention LayerNorm ---
+        if use_te and args.num_experts is None:
+            mglayer.mlp.linear_fc1.layer_norm_weight.copy_(
+                hflayer.post_attention_layernorm.weight
+            )
+        else:
+            mglayer.pre_mlp_layernorm.weight.copy_(
+                hflayer.post_attention_layernorm.weight
+            )
+
+    def _convert_layer_mg_to_hf(self, mglayer, hflayer, args):
+        use_te = args.transformer_impl == "transformer_engine"
+        num_query_groups = args.num_query_groups
+        hidden_size = args.hidden_size
+        head_dim = getattr(args, "kv_channels", None) or (
+            hidden_size // args.num_attention_heads
+        )
+        value_num_per_group = args.num_attention_heads // num_query_groups
+
+        # --- Input LayerNorm ---
+        if use_te:
+            hflayer.input_layernorm.weight.copy_(
+                mglayer.self_attention.linear_qkv.layer_norm_weight
+            )
+        else:
+            hflayer.input_layernorm.weight.copy_(mglayer.input_layernorm.weight)
+
+        # --- QKV split ---
+        qkv_w = mglayer.self_attention.linear_qkv.weight.view(
+            num_query_groups, -1, head_dim, hidden_size
+        )
+        q_w, k_w, v_w = torch.split(
+            qkv_w, [value_num_per_group, 1, 1], dim=1
+        )
+        hflayer.self_attn.q_proj.weight.copy_(q_w.reshape(-1, hidden_size))
+        hflayer.self_attn.k_proj.weight.copy_(k_w.reshape(-1, hidden_size))
+        hflayer.self_attn.v_proj.weight.copy_(v_w.reshape(-1, hidden_size))
+        # No QKV bias for Qwen3.
+
+        # --- Q/K LayerNorm ---
+        if getattr(args, "qk_layernorm", False):
+            hflayer.self_attn.q_norm.weight.copy_(
+                mglayer.self_attention.q_layernorm.weight
+            )
+            hflayer.self_attn.k_norm.weight.copy_(
+                mglayer.self_attention.k_layernorm.weight
+            )
+
+        # --- O projection ---
+        hflayer.self_attn.o_proj.weight.copy_(
+            mglayer.self_attention.linear_proj.weight
+        )
+
+        # --- MLP / MoE ---
+        if args.num_experts is None:
+            gate_w, up_w = torch.split(
+                mglayer.mlp.linear_fc1.weight, args.ffn_hidden_size
+            )
+            hflayer.mlp.gate_proj.weight.copy_(gate_w)
+            hflayer.mlp.up_proj.weight.copy_(up_w)
+            hflayer.mlp.down_proj.weight.copy_(mglayer.mlp.linear_fc2.weight)
+        else:
+            hflayer.mlp.gate.weight.copy_(mglayer.mlp.router.weight)
+            for mg_expert, hf_expert in zip(
+                mglayer.mlp.experts.local_experts, hflayer.mlp.experts
+            ):
+                gate_w, up_w = torch.split(
+                    mg_expert.linear_fc1.weight, args.moe_ffn_hidden_size
+                )
+                hf_expert.gate_proj.weight.copy_(gate_w)
+                hf_expert.up_proj.weight.copy_(up_w)
+                hf_expert.down_proj.weight.copy_(mg_expert.linear_fc2.weight)
+            if hasattr(hflayer.mlp, "shared_expert_gate") and hasattr(
+                mglayer.mlp, "shared_expert_gate"
+            ):
+                hflayer.mlp.shared_expert_gate.weight.copy_(
+                    mglayer.mlp.shared_expert_gate.weight
+                )
+                shared_gate, shared_up = torch.split(
+                    mglayer.mlp.shared_expert.linear_fc1.weight,
+                    args.shared_moe_ffn_hidden_size,
+                )
+                hflayer.mlp.shared_expert.gate_proj.weight.copy_(shared_gate)
+                hflayer.mlp.shared_expert.up_proj.weight.copy_(shared_up)
+                hflayer.mlp.shared_expert.down_proj.weight.copy_(
+                    mglayer.mlp.shared_expert.linear_fc2.weight
+                )
+
+        # --- Post-attention LayerNorm ---
+        if use_te and args.num_experts is None:
+            hflayer.post_attention_layernorm.weight.copy_(
+                mglayer.mlp.linear_fc1.layer_norm_weight
+            )
+        else:
+            hflayer.post_attention_layernorm.weight.copy_(
+                mglayer.pre_mlp_layernorm.weight
+            )
+
+
+# ---------------------------------------------------------------------------
 # Registry
 # ---------------------------------------------------------------------------
 
 _BRIDGE_REGISTRY = {
     "qwen2": Qwen2Bridge,
     "qwen2_5": Qwen2Bridge,
+    "qwen3": Qwen3Bridge,
+    "qwen3_moe": Qwen3Bridge,
 }
 
 

--- a/src/autoalign/megatron/model_config.py
+++ b/src/autoalign/megatron/model_config.py
@@ -44,6 +44,10 @@ _FIELD_MAPPING: Dict[str, List[str]] = {
     "norm_epsilon": ["rms_norm_eps", "layer_norm_epsilon", "layer_norm_eps"],
     "rotary_base": ["rope_theta"],
     "attention_dropout": ["attention_dropout"],
+    "kv_channels": ["head_dim"],
+    "moe_ffn_hidden_size": ["moe_intermediate_size"],
+    "num_experts": ["num_experts"],
+    "moe_router_topk": ["num_experts_per_tok"],
 }
 
 # Fields that require value inversion (HF True → Megatron False, etc.)
@@ -60,6 +64,30 @@ _MODEL_TYPE_DEFAULTS: Dict[str, Dict[str, Any]] = {
         "use_rotary_position_embeddings": True,
         "disable_bias_linear": True,
         "add_qkv_bias": True,
+        "rotary_percent": 1.0,
+        "patch_tokenizer_type": "Qwen2Tokenizer",
+    },
+    # NOTE: order matters — `_match_model_type` uses startswith, so the more
+    # specific `qwen3_moe` must come before `qwen3`.
+    "qwen3_moe": {
+        "swiglu": True,
+        "normalization": "RMSNorm",
+        "position_embedding_type": "rope",
+        "use_rotary_position_embeddings": True,
+        "disable_bias_linear": True,
+        "add_qkv_bias": False,
+        "qk_layernorm": True,
+        "rotary_percent": 1.0,
+        "patch_tokenizer_type": "Qwen2Tokenizer",
+    },
+    "qwen3": {
+        "swiglu": True,
+        "normalization": "RMSNorm",
+        "position_embedding_type": "rope",
+        "use_rotary_position_embeddings": True,
+        "disable_bias_linear": True,
+        "add_qkv_bias": False,
+        "qk_layernorm": True,
         "rotary_percent": 1.0,
         "patch_tokenizer_type": "Qwen2Tokenizer",
     },

--- a/src/autoalign/megatron/model_config.py
+++ b/src/autoalign/megatron/model_config.py
@@ -56,6 +56,17 @@ _INVERTED_BOOL_FIELDS: Dict[str, List[str]] = {
 }
 
 # Per-model-type fixed architectural flags
+#
+# NOTE on dropout:
+#   Megatron's arguments.py defaults --hidden-dropout=0.1 and
+#   --attention-dropout=0.1 (pretraining-era values). Modern HF decoder
+#   models (Qwen2/3, LLaMA, …) run with dropout=0 — their config.json
+#   exposes attention_dropout=0.0 but no hidden_dropout field at all, so
+#   unless we force it here every Megatron SFT run silently trains with
+#   hidden/embedding dropout=0.1 while the HF reference does not. That
+#   silently diverges loss/grad dynamics from iteration 1. Hard-code
+#   hidden_dropout=0.0 in the model defaults so every HF→Megatron run
+#   matches the HF reference.
 _MODEL_TYPE_DEFAULTS: Dict[str, Dict[str, Any]] = {
     "qwen2": {
         "swiglu": True,
@@ -66,6 +77,8 @@ _MODEL_TYPE_DEFAULTS: Dict[str, Dict[str, Any]] = {
         "add_qkv_bias": True,
         "rotary_percent": 1.0,
         "patch_tokenizer_type": "Qwen2Tokenizer",
+        "hidden_dropout": 0.0,
+        "attention_dropout": 0.0,
     },
     # NOTE: order matters — `_match_model_type` uses startswith, so the more
     # specific `qwen3_moe` must come before `qwen3`.
@@ -79,6 +92,8 @@ _MODEL_TYPE_DEFAULTS: Dict[str, Dict[str, Any]] = {
         "qk_layernorm": True,
         "rotary_percent": 1.0,
         "patch_tokenizer_type": "Qwen2Tokenizer",
+        "hidden_dropout": 0.0,
+        "attention_dropout": 0.0,
     },
     "qwen3": {
         "swiglu": True,
@@ -90,6 +105,8 @@ _MODEL_TYPE_DEFAULTS: Dict[str, Dict[str, Any]] = {
         "qk_layernorm": True,
         "rotary_percent": 1.0,
         "patch_tokenizer_type": "Qwen2Tokenizer",
+        "hidden_dropout": 0.0,
+        "attention_dropout": 0.0,
     },
 }
 

--- a/src/autoalign/megatron/registry.py
+++ b/src/autoalign/megatron/registry.py
@@ -225,6 +225,7 @@ def _ensure_auto_registered():
         return
     _AUTO_REGISTERED = True
     _register_qwen2()
+    _register_qwen3()
 
 
 def _register_qwen2():
@@ -249,3 +250,29 @@ def _register_qwen2():
         get_layer_spec_te=get_gpt_layer_with_transformer_engine_spec,
         model_cls=GPTModel,
     ))
+
+
+def _register_qwen3():
+    """Register the Qwen3 / Qwen3-MoE model family.
+
+    Reuses stock mcore layer spec functions, which already accept
+    ``qk_layernorm=True`` and wire up Q/K LayerNorm submodules. Only the
+    bridge differs from Qwen2.
+    """
+    from megatron.core.models.gpt import GPTModel
+    from megatron.core.transformer import TransformerConfig
+    from megatron.core.models.gpt.gpt_layer_specs import (
+        get_gpt_layer_local_spec,
+        get_gpt_layer_with_transformer_engine_spec,
+    )
+    from autoalign.megatron.bridge import Qwen3Bridge
+
+    for mt in ("qwen3", "qwen3_moe"):
+        register_megatron_model(MegatronModelMeta(
+            model_type=mt,
+            bridge_cls=Qwen3Bridge,
+            transformer_config_cls=TransformerConfig,
+            get_layer_spec_local=get_gpt_layer_local_spec,
+            get_layer_spec_te=get_gpt_layer_with_transformer_engine_spec,
+            model_cls=GPTModel,
+        ))

--- a/src/autoalign/megatron/toolkits/checkpoint/qwen/common.py
+++ b/src/autoalign/megatron/toolkits/checkpoint/qwen/common.py
@@ -49,7 +49,7 @@ from megatron.training.initialize import initialize_megatron
 from megatron.training import get_args
 from megatron.training.utils import get_ltor_masks_and_position_ids
 
-from autoalign.megatron.bridge import Qwen2Bridge, clone_state_dict
+from autoalign.megatron.bridge import Qwen2Bridge, clone_state_dict, get_bridge
 from autoalign.megatron.registry import make_model_provider
 from autoalign.megatron.patch.arguments import get_patch_args as get_patch_args_autoalign
 
@@ -95,7 +95,7 @@ def load_megatron_model(args):
 
     Returns the model with a full (un-sharded) state dict loaded.
     """
-    bridge = Qwen2Bridge()
+    bridge = get_bridge(getattr(args, "model_type_name", None) or "qwen2")
 
     args.tensor_model_parallel_size = args.target_tensor_model_parallel_size
     args.pipeline_model_parallel_size = args.target_pipeline_model_parallel_size
@@ -113,7 +113,7 @@ def load_megatron_model(args):
                         "tokenizer*", "vocab.json", "merges.txt"]:
             os.system(f"cp -rf {args.hf_ckpt_path}/{pattern} {target_dir} 2>/dev/null")
 
-    model = make_model_provider("qwen2")()
+    model = make_model_provider(getattr(args, "model_type_name", None) or "qwen2")()
 
     # Load and gather checkpoint shards via bridge
     state_dict = bridge.load_mg_state_dict(args)
@@ -182,11 +182,14 @@ def check_hf_mg_forward(hfmodel, mgmodel, mgargs):
     def print_input_hook(module, args, kwargs, layer_idx, mode):
         frame, name = mode.split('-')
         if frame == 'hf':
-            hf_hiddens[layer_idx][name] = args[0].transpose(0, 1)
-        elif frame == 'mg' and 'layer' in mode:
-            mg_hiddens[layer_idx][name] = kwargs.get('hidden_states')
+            val = args[0]
+            if val.dim() == 3 and name != 'mlp_in':
+                val = val.transpose(0, 1)
+            hf_hiddens[layer_idx][name] = val.reshape(-1, hidden_size)
+        elif frame == 'mg' and name == 'layer_in':
+            mg_hiddens[layer_idx][name] = kwargs.get('hidden_states').reshape(-1, hidden_size)
         elif frame == 'mg':
-            mg_hiddens[layer_idx][name] = args[0]
+            mg_hiddens[layer_idx][name] = args[0].reshape(-1, hidden_size)
 
     def print_output_hook(module, args, kwargs, output, layer_idx, mode):
         frame, name = mode.split('-')
@@ -207,6 +210,10 @@ def check_hf_mg_forward(hfmodel, mgmodel, mgargs):
         elif mode in ['hf-attn_out']:
             hf_hiddens[layer_idx][name] = output[0].reshape(-1, hidden_size)
         elif mode in ['mg-attn_out']:
+            mg_hiddens[layer_idx][name] = output[0].reshape(-1, hidden_size)
+        elif mode in ['hf-mlp_out']:
+            hf_hiddens[layer_idx][name] = output.reshape(-1, hidden_size)
+        elif mode in ['mg-mlp_out']:
             mg_hiddens[layer_idx][name] = output[0].reshape(-1, hidden_size)
 
     if mgargs.untie_embeddings_and_output_weights:
@@ -232,6 +239,12 @@ def check_hf_mg_forward(hfmodel, mgmodel, mgargs):
         layer.self_attn.register_forward_hook(
             partial(print_output_hook, layer_idx=idx, mode='hf-attn_out'), with_kwargs=True,
         )
+        layer.mlp.register_forward_pre_hook(
+            partial(print_input_hook, layer_idx=idx, mode='hf-mlp_in'), with_kwargs=True,
+        )
+        layer.mlp.register_forward_hook(
+            partial(print_output_hook, layer_idx=idx, mode='hf-mlp_out'), with_kwargs=True,
+        )
 
     for idx, layer in enumerate(mgmodel.decoder.layers):
         layer.register_forward_pre_hook(
@@ -246,6 +259,12 @@ def check_hf_mg_forward(hfmodel, mgmodel, mgargs):
         layer.self_attention.register_forward_hook(
             partial(print_output_hook, layer_idx=idx, mode='mg-attn_out'), with_kwargs=True,
         )
+        layer.mlp.register_forward_pre_hook(
+            partial(print_input_hook, layer_idx=idx, mode='mg-mlp_in'), with_kwargs=True,
+        )
+        layer.mlp.register_forward_hook(
+            partial(print_output_hook, layer_idx=idx, mode='mg-mlp_out'), with_kwargs=True,
+        )
 
     input_ids = torch.tensor(
         [[151644, 8506, 22564, 27608, 75188, 4344, 121395, 61991, 79554, 36689]]
@@ -255,6 +274,12 @@ def check_hf_mg_forward(hfmodel, mgmodel, mgargs):
     )
     print(hfmodel)
     print(mgmodel)
+
+    # Disable dropout — without .eval() both models are in train mode and
+    # embedding_dropout / hidden_dropout fire randomly, producing huge spurious
+    # diffs that compound across layers.
+    hfmodel.eval()
+    mgmodel.eval()
 
     is_oom = False
     with torch.inference_mode():
@@ -294,6 +319,9 @@ def check_hf_mg_forward(hfmodel, mgmodel, mgargs):
             )
 
     if not is_oom:
+        # Megatron pads vocab; trim to HF vocab size for comparison
+        hf_vocab = hflogits.shape[-1]
+        mglogits = mglogits[..., :hf_vocab]
         same_num = (hflogits != mglogits).sum()
         diff_num = ((hflogits - mglogits) > epsilon).sum()
         diff_max = (hflogits - mglogits).abs().max()
@@ -301,6 +329,16 @@ def check_hf_mg_forward(hfmodel, mgmodel, mgargs):
             f'logits: {same_num}, diff>{epsilon}:'
             f'[{diff_num}/{hflogits.numel()}] diff_max:{diff_max}'
         )
+        # Token-level greedy argmax agreement (one-step prediction).
+        hf_top = hflogits.float().argmax(dim=-1).cpu()
+        mg_top = mglogits.float().argmax(dim=-1).cpu()
+        agree = (hf_top == mg_top).sum().item()
+        total = hf_top.numel()
+        print(
+            f'token_argmax_agreement: {agree}/{total} ({100.0*agree/total:.2f}%)'
+        )
+        print(f'  hf_top: {hf_top.flatten().tolist()}')
+        print(f'  mg_top: {mg_top.flatten().tolist()}')
 
 
 # ---------------------------------------------------------------------------
@@ -311,15 +349,20 @@ def main():
     initialize_megatron(extra_args_provider=add_extra_args)
     args = get_args()
 
-    # NullTokenizer sets padded_vocab_size=0; fix it from HF config.json.
-    if args.padded_vocab_size == 0:
-        import math
-        hf_cfg = AutoConfig.from_pretrained(args.model_path)
-        vocab_size = hf_cfg.vocab_size
-        multiple = args.make_vocab_size_divisible_by * args.tensor_model_parallel_size
-        args.padded_vocab_size = int(math.ceil(vocab_size / multiple) * multiple)
+    # Recompute padded_vocab_size with the *target* TP, not the current
+    # args.tensor_model_parallel_size (which is still 1 in the convert path —
+    # the convert script only sets --target-tensor-model-parallel-size).
+    # initialize_megatron has already padded based on TP=1, but the
+    # training-time model loads with TP=N, so the multiples differ and we get
+    # a vocab-size mismatch on load. Always overwrite here.
+    hf_cfg = AutoConfig.from_pretrained(args.model_path)
+    vocab_size = hf_cfg.vocab_size
+    target_tp = getattr(args, "target_tensor_model_parallel_size",
+                        args.tensor_model_parallel_size)
+    multiple = args.make_vocab_size_divisible_by * target_tp
+    args.padded_vocab_size = ((vocab_size + multiple - 1) // multiple) * multiple
 
-    bridge = Qwen2Bridge()
+    bridge = get_bridge(getattr(args, "model_type_name", None) or "qwen2")
 
     if args.convert_checkpoint_from_megatron_to_transformers:
         # Megatron -> HF
@@ -333,10 +376,20 @@ def main():
     else:
         # HF -> Megatron
         config = AutoConfig.from_pretrained(args.load)
+        # Match HF dtype to Megatron dtype so the precision test isn't biased
+        # by silent up/down-casts. If neither --bf16 nor --fp16, use fp32.
+        if args.bf16:
+            hf_dtype = torch.bfloat16
+        elif args.fp16:
+            hf_dtype = torch.float16
+        else:
+            # Preserve the original behavior when no precision flag is passed
+            # (used by all existing convert scripts indirectly via PRECISION).
+            hf_dtype = config.torch_dtype
         hf_model = AutoModelForCausalLM.from_pretrained(
-            args.load, torch_dtype=config.torch_dtype,
+            args.load, torch_dtype=hf_dtype,
         )
-        mg_model = make_model_provider("qwen2")()
+        mg_model = make_model_provider(getattr(args, "model_type_name", None) or "qwen2")()
         bridge.hf_to_mg(hf_model, mg_model, args)
         if getattr(args, 'test_convert_precision', False) and not args.num_experts:
             check_hf_mg_forward(hf_model, mg_model, args)


### PR DESCRIPTION
 ## Summary
  - Add Qwen3Bridge (extends Qwen2Bridge) with Qwen3 architecture differences: no QKV bias, Q/K RMSNorm
  (qk_layernorm), no shared-expert gate for Qwen3-MoE
  - Register qwen3 / qwen3_moe in model registry and config auto-derivation, including new field mappings
  (kv_channels, num_experts, moe_router_topk, moe_ffn_hidden_size)
  - Fix vocab-padding in embedding/lm_head copy — Megatron pads vocab to vocab_divisor × tp_size, previously
  caused shape mismatch
  - Fix weight-tying with PP>1 — last PP rank now correctly gets output_layer.weight from embedding when tied
  - Fix head_dim computation to use kv_channels when available (needed for models where head_dim ≠ hidden_size
   / num_heads)
  - Fix hidden/attention dropout: Megatron defaults to 0.1, but HF Qwen2/3/LLaMA all use 0.0 — now hard-coded
  to 0.0 to match HF reference