### PR TITLE
add variable-length dynamic padding for SFT

### DIFF
--- a/src/autoalign/megatron/patch/data/online_dataset.py
+++ b/src/autoalign/megatron/patch/data/online_dataset.py
@@ -142,11 +142,12 @@ class OnlineSFTDataset(torch.utils.data.Dataset):
         input_ids = tokenized.input_ids
 
         # Pad to seq_length (same as GPTDatasetSFTConv._pad_and_mask)
-        pad_len = self.seq_length - len(input_ids)
+        actual_len = len(input_ids)
+        pad_len = self.seq_length - actual_len
         text = np.array(input_ids + [self.pad_id] * pad_len, dtype=np.int64)
         label = np.array(labels + [self.mask_id] * pad_len, dtype=np.int64)
 
-        return {"conv_text": text, "conv_label": label}
+        return {"conv_text": text, "conv_label": label, "seq_len": actual_len}
 
 
 # ---------------------------------------------------------------------------
@@ -190,23 +191,25 @@ class OnlineDPODataset(torch.utils.data.Dataset):
         )
         input_ids = tokenized.input_ids
 
-        pad_len = self.seq_length - len(input_ids)
+        actual_len = len(input_ids)
+        pad_len = self.seq_length - actual_len
         text = np.array(input_ids + [self.pad_id] * pad_len, dtype=np.int64)
         label = np.array(labels + [self.mask_id] * pad_len, dtype=np.int64)
-        return text, label
+        return text, label, actual_len
 
     def __getitem__(self, idx):
         data_idx = self.indices[idx]
         json_line = self.data[data_idx]
 
-        chosen_text, chosen_label = self._tokenize_branch(json_line["chosen"])
-        rejected_text, rejected_label = self._tokenize_branch(json_line["rejected"])
+        chosen_text, chosen_label, chosen_len = self._tokenize_branch(json_line["chosen"])
+        rejected_text, rejected_label, rejected_len = self._tokenize_branch(json_line["rejected"])
 
         return {
             "chosen_text": chosen_text,
             "chosen_label": chosen_label,
             "rejected_text": rejected_text,
             "rejected_label": rejected_label,
+            "seq_len": max(chosen_len, rejected_len),
         }
 
 

--- a/src/autoalign/megatron/patch/data/utils.py
+++ b/src/autoalign/megatron/patch/data/utils.py
@@ -237,12 +237,18 @@ def get_batch_on_this_tp_rank_idxmap_sft_conv(data_iterator):
         conv_label = data['conv_label'].long()
         
         # Dynamic padding requires variable-shape PP p2p when pipeline parallelism is enabled.
+        divisor = args.tensor_model_parallel_size * getattr(args, 'context_parallel_size', 1)
+        if divisor > 1 and args.seq_length % divisor != 0:
+            raise ValueError(
+                f"args.seq_length ({args.seq_length}) must be divisible by "
+                f"tensor_model_parallel_size * context_parallel_size ({divisor}) "
+                "to keep sequence-parallel shapes consistent."
+            )
         if 'seq_len' in data and (
             args.pipeline_model_parallel_size == 1 or getattr(args, 'variable_seq_lengths', False)
         ):
             cur_max_seq_length = min(int(data['seq_len'].max()), args.seq_length)
             # Round up to TP * CP so sequence-parallel reduce-scatter is valid
-            divisor = args.tensor_model_parallel_size * getattr(args, 'context_parallel_size', 1)
             if divisor > 1:
                 cur_max_seq_length = ((cur_max_seq_length + divisor - 1) // divisor) * divisor
         else:

--- a/src/autoalign/megatron/patch/data/utils.py
+++ b/src/autoalign/megatron/patch/data/utils.py
@@ -236,9 +236,10 @@ def get_batch_on_this_tp_rank_idxmap_sft_conv(data_iterator):
         conv_tokens = data['conv_text'].long()
         conv_label = data['conv_label'].long()
         
-        # Dynamic padding: trim to actual max content length in this
-        # micro-batch so the model doesn't waste compute on padding tokens.
-        if 'seq_len' in data:
+        # Dynamic padding requires variable-shape PP p2p when pipeline parallelism is enabled.
+        if 'seq_len' in data and (
+            args.pipeline_model_parallel_size == 1 or getattr(args, 'variable_seq_lengths', False)
+        ):
             cur_max_seq_length = min(int(data['seq_len'].max()), args.seq_length)
             # Round up to TP * CP so sequence-parallel reduce-scatter is valid
             divisor = args.tensor_model_parallel_size * getattr(args, 'context_parallel_size', 1)

--- a/src/autoalign/megatron/patch/data/utils.py
+++ b/src/autoalign/megatron/patch/data/utils.py
@@ -236,9 +236,16 @@ def get_batch_on_this_tp_rank_idxmap_sft_conv(data_iterator):
         conv_tokens = data['conv_text'].long()
         conv_label = data['conv_label'].long()
         
-        # Use fixed seq_length to avoid PP send/recv size mismatch across
-        # DP ranks and PP stages (each may compute a different dynamic max).
-        cur_max_seq_length = args.seq_length
+        # Dynamic padding: trim to actual max content length in this
+        # micro-batch so the model doesn't waste compute on padding tokens.
+        if 'seq_len' in data:
+            cur_max_seq_length = min(int(data['seq_len'].max()), args.seq_length)
+            # Round up to TP * CP so sequence-parallel reduce-scatter is valid
+            divisor = args.tensor_model_parallel_size * getattr(args, 'context_parallel_size', 1)
+            if divisor > 1:
+                cur_max_seq_length = ((cur_max_seq_length + divisor - 1) // divisor) * divisor
+        else:
+            cur_max_seq_length = args.seq_length
 
         cur_max_seq_length = torch.tensor(
             [cur_max_seq_length],


### PR DESCRIPTION
  - Add dynamic padding to Megatron SFT so JSON batches are padded to the actual max sequence length in each batch instead of always padding to `--seq-length`.
  - For pipeline-parallel JSON SFT, require `--variable-seq-lengths` when using dynamic padding; otherwise fall back to fixed `--seq-length` padding to avoid shape mismatches between pipeline stages.